### PR TITLE
KB-10186 | Learner Portal | If user has Primary details, in the Service history default data is not calculating for Profile page percentage.

### DIFF
--- a/core/platform-common/src/main/java/org/sunbird/keys/JsonKey.java
+++ b/core/platform-common/src/main/java/org/sunbird/keys/JsonKey.java
@@ -701,5 +701,7 @@ public final class JsonKey {
   public static final String USER_EXTENDED_PROFILE_READ_FIELDS = "user_extended_profile_read_fields";
   public static final String PROFILE_COMPLETION_FIELD_WEIGHT="profile.completion.field.weight";
   public static final String PROFILE_COMPLETION_PERCENTAGE = "profileCompletionPercentage";
+  public static final String SERVICE_HISTORY = "serviceHistory";
+
   private JsonKey() {}
 }

--- a/service/src/main/java/org/sunbird/service/user/UserProfileReadService.java
+++ b/service/src/main/java/org/sunbird/service/user/UserProfileReadService.java
@@ -787,7 +787,16 @@ public class UserProfileReadService {
       boolean isFilled;
       try {
         if (requiredExtendedUserFields.contains(field)) {
-          isFilled = fetchExtendedUserDetailsFromDatabase(userId, field, requestContext);
+          isFilled = fetchExtendedUserDetailsFromDatabase(userId, field, requestContext) || (JsonKey.SERVICE_HISTORY.equalsIgnoreCase(field) &&
+                  Optional.ofNullable(profileData.get(JsonKey.PROFILE_DETAILS))
+                          .filter(Map.class::isInstance)
+                          .map(Map.class::cast)
+                          .map(details -> details.get(JsonKey.PROFESSIONAL_DETAILS))
+                          .filter(List.class::isInstance)
+                          .map(List.class::cast)
+                          .map(org.apache.commons.collections4.CollectionUtils::isNotEmpty)
+                          .orElse(false));
+
         } else {
           Object value = profileData.getOrDefault(field, nestedData.get(field));
           isFilled = value != null && !value.toString().trim().isEmpty();


### PR DESCRIPTION

1.If user has Professional details and the Service history data is not there then we need to add the profile completion percentage based on the professional details