### PR TITLE
KB-14578 | BE | DEV| API Implementation for bulk creation of Non-GovtUsers

### DIFF
--- a/service/src/main/java/org/sunbird/actor/user/SSOUserCreateActor.java
+++ b/service/src/main/java/org/sunbird/actor/user/SSOUserCreateActor.java
@@ -569,7 +569,16 @@ public class SSOUserCreateActor extends UserBaseActor {
 
   private void populatePublicRoles(Request actorMessage) {
     Map<String, Object> userMap = actorMessage.getRequest();
-    userMap.put(JsonKey.ROLES, Arrays.asList(JsonKey.PUBLIC));
+    List<String> roles = (List<String>) userMap.get(JsonKey.ROLES);
+    // Only set PUBLIC role if roles are not already provided in the request
+    if (roles == null || roles.isEmpty()) {
+      logger.info(actorMessage.getRequestContext(),
+          "SSOUserCreateActor:populatePublicRoles: No roles provided in request, setting default PUBLIC role");
+      userMap.put(JsonKey.ROLES, Arrays.asList(JsonKey.PUBLIC));
+    } else {
+      logger.info(actorMessage.getRequestContext(),
+          "SSOUserCreateActor:populatePublicRoles: Roles provided in request: {}, preserving them", roles);
+    }
   }
 
   private void validateRoleAssignment(Request actorMessage, String targetOrgId) {


### PR DESCRIPTION
Fix: Preserve caller-specified roles in bulk user creation

The populatePublicRoles method was unconditionally overwriting all roles with PUBLIC, even when roles were explicitly provided in the request. This caused non-government (volunteer) users created via bulk upload to be assigned the PUBLIC role instead of the intended VOLUNTEER role.

Root Cause:
- The createBulkUsers operation calls populatePublicRoles which hardcoded roles to [PUBLIC]
- When cb-ext sends roles: ["VOLUNTEER"] for non-govt users, it was being ignored and replaced with PUBLIC

Solution:
- Modified populatePublicRoles to check if roles are already present in the request
- Only sets default PUBLIC role when roles are null or empty
- Preserves caller-specified roles (VOLUNTEER, etc.) when provided
- Added logging to track when roles are preserved vs. defaulted