### PR TITLE
KB-14644:volunteer disabled if Ngo org status is deactivated

### DIFF
--- a/core/platform-common/src/main/java/org/sunbird/exception/ResponseMessage.java
+++ b/core/platform-common/src/main/java/org/sunbird/exception/ResponseMessage.java
@@ -36,7 +36,7 @@ public interface ResponseMessage {
     String RESOURCE_NOT_FOUND = "Requested {0} resource not found";
     String MAX_ALLOWED_SIZE_LIMIT_EXCEED = "Max allowed size is {0}";
     String INACTIVE_USER = "User is Inactive. Please make it active to proceed.";
-    String DISABLED_USER = "User account is disabled.";
+    String DISABLED_USER = "Organisation is deactivated, hence the user is restricted to login.";
     String INVALID_VALUE = "Invalid {0}: {1}. Valid values are: {2}.";
     String INVALID_PARAMETER = "Please provide valid {0}.";
     String INVALID_LOCATION_DELETE_REQUEST =

--- a/service/src/main/java/org/sunbird/service/user/impl/UserServiceImpl.java
+++ b/service/src/main/java/org/sunbird/service/user/impl/UserServiceImpl.java
@@ -297,7 +297,7 @@ public class UserServiceImpl implements UserService {
             logger.info(context, "UserServiceImpl:userLookUpByKey: blocking VOLUNTEER userId = " + userId
                     + " because orgId = " + orgId + " is deactivated or missing");
             throw new ProjectCommonException(
-                    ResponseCode.invalidParameter,
+                    ResponseCode.disbledUser,
                     ResponseCode.disbledUser.getErrorMessage(),
                     ResponseCode.CLIENT_ERROR.getResponseCode());
           }


### PR DESCRIPTION
The VOLUNTEER-org-deactivation check in UserServiceImpl.userLookUpByKey threw ProjectCommonException with a mismatched code/message pair: the errorCode came from ResponseCode.invalidParameter while the message text came from ResponseCode.disbledUser ("User account is disabled."), so callers received an inconsistent errCode/errmsg combination and a message that didn't explain the actual reason for the failure.